### PR TITLE
Remove id from graphql query

### DIFF
--- a/tests/snapshots/snap_test_viewer_graphql.py
+++ b/tests/snapshots/snap_test_viewer_graphql.py
@@ -10,7 +10,6 @@ snapshots = Snapshot()
 snapshots['test_big_gql 1'] = {
     'data': {
         'viewer': {
-            'id': 'R1VzZXI6MjE=',
             'profile': {
                 'investSuggestions': {
                     'edges': [
@@ -21,14 +20,12 @@ snapshots['test_big_gql 1'] = {
                                     'edges': [
                                         {
                                             'node': {
-                                                'id': 'R0ludmVzdG1lbnRCdWNrZXRBdHRyaWJ1dGU6Nw==',
                                                 'isGood': True,
                                                 'text': 'Blabla'
                                             }
                                         }
                                     ]
                                 },
-                                'id': 'R0ludmVzdG1lbnRCdWNrZXQ6MTc=',
                                 'isOwner': True,
                                 'name': 'i1',
                                 'public': False,
@@ -37,7 +34,6 @@ snapshots['test_big_gql 1'] = {
                                         {
                                             'node': {
                                                 'end': None,
-                                                'id': 'R0ludmVzdG1lbnRTdG9ja0NvbmZpZ3VyYXRpb246MTI=',
                                                 'quantity': 1.0,
                                                 'start': '2017-05-09',
                                                 'stock': {
@@ -56,7 +52,6 @@ snapshots['test_big_gql 1'] = {
                 },
                 'stockFind': [
                     {
-                        'id': 'R1N0b2NrOjE1',
                         'quoteInRange': [
                             {
                                 'date': '2017-05-08',

--- a/tests/test_viewer_graphql.py
+++ b/tests/test_viewer_graphql.py
@@ -299,13 +299,11 @@ def test_big_gql(rf, snapshot):
     executed = client.execute("""
 {
   viewer {
-    id
     username
     profile {
       investSuggestions {
         edges {
           node {
-            id
             name
             public
             available
@@ -313,7 +311,6 @@ def test_big_gql(rf, snapshot):
             description {
               edges {
                 node {
-                  id
                   text
                   isGood
                 }
@@ -322,7 +319,6 @@ def test_big_gql(rf, snapshot):
             stocks {
               edges {
                 node {
-                  id
                   quantity
                   stock {
                     name
@@ -339,7 +335,6 @@ def test_big_gql(rf, snapshot):
         }
       }
       stockFind(text: "GO") {
-        id
         quoteInRange(start: "2017-05-07", end: "2017-05-11") {
           value
           date


### PR DESCRIPTION
Wrong IDs were making the query fail when new tests were added. It does not give us any big benefit in the current configuration, so let's remove it